### PR TITLE
Fix Android orientation to portrait

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -14,7 +14,7 @@
     <activity
         android:name="com.segilmez.game3072.android.AndroidLauncher"
         android:label="@string/app_name"
-        android:screenOrientation="landscape"
+        android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout"
         android:exported="true">
         <intent-filter>


### PR DESCRIPTION
## Summary
- set Android app orientation to portrait instead of landscape

## Testing
- `./gradlew test` *(fails: no route to host)*